### PR TITLE
Adding parse_req to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
+from pip.req import parse_requirements
+from pip.download import PipSession
 
 setup(
     name='vprof',
@@ -23,5 +25,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Topic :: Software Development',
+    ],
+    install_requires=[
+        str(req.req) for req in parse_requirements("requirements.txt", session=PipSession())
     ],
 )


### PR DESCRIPTION
When installing via pip the psutil requirement isn't installed. Also it might be a good idea to pin the requirement :-)

See:
```
ses: ~ $ virtualenv test-venv
New python executable in test-venv/bin/python2.7
Also creating executable in test-venv/bin/python
Installing setuptools, pip, wheel...sourcedone.
ses: ~ $ source test-venv/bin/activate
(test-venv)ses: ~ $ pip install vprof
You are using pip version 7.1.0, however version 7.1.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting vprof
Installing collected packages: vprof
Successfully installed vprof-0.1.0
(test-venv)ses: ~ $ vprof
Traceback (most recent call last):
  File "/Users/ses/test-venv/bin/vprof", line 7, in <module>
    from vprof.__main__ import main
  File "/Users/ses/test-venv/lib/python2.7/site-packages/vprof/__main__.py", line 4, in <module>
    import profile_wrappers
  File "/Users/ses/test-venv/lib/python2.7/site-packages/vprof/profile_wrappers.py", line 9, in <module>
    import psutil
ImportError: No module named psutil
(test-venv)ses: ~ $
```

This PR adds the requirements in a fairly dynamic way to setup.py.