### PR TITLE
Don't suppress ImportErrors.

### DIFF
--- a/vprof/__main__.py
+++ b/vprof/__main__.py
@@ -3,7 +3,6 @@ import argparse
 import os
 import sys
 
-from vprof import base_profile
 from vprof import stats_server
 from vprof import profiler
 
@@ -80,9 +79,6 @@ def main():
         except profiler.BadOptionError as exc:
             print(exc)
             sys.exit(_ERROR_MSG['bad option']['code'])
-        except base_profile.ProfilerRuntimeException as exc:
-            print(exc)
-            sys.exit(_ERROR_MSG['runtime error']['code'])
 
     if not args.debug_mode:
         sys.stderr = open(os.devnull, "w")

--- a/vprof/base_profile.py
+++ b/vprof/base_profile.py
@@ -3,16 +3,6 @@ import os
 import sys
 
 
-class Error(Exception):
-    """Base exception for current module."""
-    pass
-
-
-class ProfilerRuntimeException(Error):
-    """Base exception for all runtime errors during profiling."""
-    pass
-
-
 def get_package_code(package_name, name_is_path=False):
     """Returns package source code.
     Args:

--- a/vprof/code_heatmap.py
+++ b/vprof/code_heatmap.py
@@ -8,16 +8,6 @@ from collections import defaultdict
 from vprof import base_profile
 
 
-class Error(Exception):
-    """Base exception for current module."""
-    pass
-
-
-class CodeHeatmapRunError(Error, base_profile.ProfilerRuntimeException):
-    """Runtime exception for code heatmap profiler."""
-    pass
-
-
 class CodeHeatmapCalculator(object):
     """Calculates Python code heatmap.
 

--- a/vprof/code_heatmap.py
+++ b/vprof/code_heatmap.py
@@ -115,9 +115,6 @@ class CodeHeatmapProfile(base_profile.BaseProfile):
                 prof.add_code(compiled_code)
             try:
                 runpy.run_path(self._run_object)
-            except ImportError:
-                raise CodeHeatmapRunError(
-                    'Unable to run package %s' % self._run_object)
             except SystemExit:
                 pass
         return self._consodalidate_stats(pkg_code, prof)
@@ -156,9 +153,6 @@ class CodeHeatmapProfile(base_profile.BaseProfile):
                 prof.add_code(compiled_code)
             try:
                 runpy.run_module(self._run_object)
-            except ImportError:
-                raise CodeHeatmapRunError(
-                    'Unable to run package %s' % self._run_object)
             except SystemExit:
                 pass
         return self._consodalidate_stats(pkg_code, prof)

--- a/vprof/memory_profile.py
+++ b/vprof/memory_profile.py
@@ -87,9 +87,6 @@ class MemoryProfile(base_profile.BaseProfile):
                 prof.add_code(compiled_code)
             try:
                 runpy.run_path(self._run_object, run_name='__main__')
-            except ImportError:
-                raise MemoryProfilerRunError(
-                    'Unable to run package %s' % self._run_object)
             except SystemExit:
                 pass
         return prof.events_list
@@ -115,9 +112,6 @@ class MemoryProfile(base_profile.BaseProfile):
                 prof.add_code(compiled_code)
             try:
                 runpy.run_module(self._run_object, run_name='__main__')
-            except ImportError:
-                raise MemoryProfilerRunError(
-                    'Unable to run package %s' % self._run_object)
             except SystemExit:
                 pass
         return prof.events_list

--- a/vprof/memory_profile.py
+++ b/vprof/memory_profile.py
@@ -10,16 +10,6 @@ from vprof import base_profile
 _BYTES_IN_MB = 1024 * 1024
 
 
-class Error(Exception):
-    """Base exception for current module."""
-    pass
-
-
-class MemoryProfilerRunError(Error, base_profile.ProfilerRuntimeException):
-    """Runtime exception for memory profiler."""
-    pass
-
-
 def get_memory_usage():
     """Returns memory usage for current process."""
     memory_info = psutil.Process(os.getpid()).memory_info()

--- a/vprof/runtime_profile.py
+++ b/vprof/runtime_profile.py
@@ -5,16 +5,6 @@ import pstats
 from vprof import base_profile
 
 
-class Error(Exception):
-    """Base exception for current module."""
-    pass
-
-
-class RuntimeProfilerRunError(Error, base_profile.ProfilerRuntimeException):
-    """Runtime exception for runtime profiler."""
-    pass
-
-
 class RuntimeProfile(base_profile.BaseProfile):
     """CProfile wrapper.
 

--- a/vprof/runtime_profile.py
+++ b/vprof/runtime_profile.py
@@ -71,9 +71,6 @@ class RuntimeProfile(base_profile.BaseProfile):
         prof.enable()
         try:
             runpy.run_path(self._run_object, run_name='__main__')
-        except ImportError:
-            raise RuntimeProfilerRunError(
-                'Unable to run package %s' % self._run_object)
         except SystemExit:
             pass
         prof.disable()
@@ -93,9 +90,6 @@ class RuntimeProfile(base_profile.BaseProfile):
         prof.enable()
         try:
             runpy.run_module(self._run_object, run_name='__main__')
-        except ImportError:
-            raise RuntimeProfilerRunError(
-                'Unable to run package %s' % self._run_object)
         except SystemExit:
             pass
         finally:


### PR DESCRIPTION
This is a tool for python programmers. We know what import errors are
and they give us some idea what we're doing wrong. Replacing them with a
vague error message doesn't help.