### PR TITLE
Updated README.md for correct calling pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,59 +23,69 @@ Feel free to open issue or send pull request!
 ## Prerequisites
 The required dependencies to build ```vprof``` from source code:
  * Python 2.7, Python 3.4 or Python 3.5
- * ```pip```
- * ```npm``` >= 3.3.12
+ * `pip`
+ * `npm` >= 3.3.12
 
-```npm``` is needed to build ```vprof``` from sources only.
+`npm` is needed to build `vprof` from sources only.
 
 ## Dependencies
-All Python and ```npm``` module dependencies are listed in ```package.json``` and ```requirements.txt```.
+All Python and `npm` module dependencies are listed in `package.json` and `requirements.txt`.
 
 ## Installation
-```vprof``` can be installed from PyPI
+`vprof` can be installed from PyPI
 
+```sh
+pip install vprof
+```
 
-    pip install vprof
+To build `vprof` from sources, clone this repository and execute
 
-
-To build ```vprof``` from sources, clone this repository and execute
 ```sh
 python setup.py deps_install && python setup.py build_ui && python setup.py install
 ```
-To install just ```vprof``` dependencies, run
 
-    python setup.py deps_install
+To install just `vprof` dependencies, run
 
+```sh
+python setup.py deps_install
+```
 
 ## Usage
+
 ```sh
-vprof -c <modes> -s <test_program>
+vprof <modes> <test_program>
 ```
 Supported modes:
 
-* ```c``` - flame graph. Renders running time visualization for ```<test_program>```.
-* ```m``` - memory graph. Shows memory usage during execution of each line of ```<test_program>```.
-* ```h``` - code heatmap. Shows number of executions of each line of code.
+* `c` - flame graph. Renders running time visualization for `<test_program>`.
+* `m` - memory graph. Shows memory usage during execution of each line of `<test_program>`.
+* `h` - code heatmap. Shows number of executions of each line of code.
 
-```<test_program>``` can be Python source file (e.g. ```testscript.py```), installed Python package (e.g. ```runpy```) or path to package (e.g. ```myproject/test_package```).
+`<test_program>` can be Python source file (e.g. `testscript.py`), installed Python package (e.g. `runpy`) or path to package (e.g. `myproject/test_package`).
 
 Use double quotes to run scripts with arguments:
+
 ```sh
 vprof -c cmh -s "testscript.py --foo --bar"
 ```
+
 Modes can be combined:
+
 ```sh
 vprof -c cm -s testscript.py
 ```
 
-```vprof``` can also profile single functions. In order to do this,
-launch ```vprof``` in remote mode:
+`vprof` can also profile single functions. In order to do this,
+launch `vprof` in remote mode:
+
 ```sh
 vprof -r
 ```
-```vprof``` will open new tab in default web browser and then wait for stats.
+
+`vprof` will open new tab in default web browser and then wait for stats.
 
 To profile a function you can do:
+
 ```python
 from vprof import profiler
 
@@ -84,17 +94,19 @@ def foo(arg1, arg2):
 
 profiler.run(foo, 'cmh', args=(arg1, arg2), host='localhost', port=8000)
 ```
-where ```cmh``` is profiling mode, ```host``` and ```port``` are hostname and
-port of ```vprof``` server launched in remote mode. Obtained stats will be
-rendered in new tab of default web browser, opened by ```vprof -r``` command.
 
-You can check ```vprof -h``` for full list of supported parameters.
+where `cmh` is profiling mode, `host` and `port` are hostname and port of `vprof` server launched in remote mode. Obtained stats will be rendered in new tab of default web browser, opened by `vprof -r` command.
+
+You can check `vprof -h` for full list of supported parameters.
 
 ## Testing
-Just run
 
-    python setup.py test && python setup.py e2e_test
+Just run:
 
+```sh
+python setup.py test && python setup.py e2e_test
+```
 
 ## License
+
 BSD


### PR DESCRIPTION
The `-c` and `-s` switches don't seem to be honored in the code itself, yet the README reflects this as if it actually works. Not using those switches allows the module to run. *Removed* those bogus switches (line 75).

Also - fixed some of the unneeded triple back-ticks (\`\`\`) inline. Markdown expects single back-ticks inline; triple back-ticks are for code blocks only.