### PR TITLE
Add suport for profiling a script that has its own arguments

### DIFF
--- a/vprof/__main__.py
+++ b/vprof/__main__.py
@@ -64,7 +64,11 @@ def main():
                         help="don't suppress error messages")
     parser.add_argument('--version', action='version',
                         version='vprof %s' % __version__)
-    args = parser.parse_args()
+    (args, leftover_args) = parser.parse_known_args()
+
+    # Override sys.argv so the command being profiled can grab its' own args if
+    # necessary
+    sys.argv[:] = leftover_args
 
     if args.config and args.remote:
         print(_ERROR_MSG['config error']['msg'])


### PR DESCRIPTION
This is a trick similar to what the default cProfile module does to allow profiling of scripts that have their own arguments.