### PR TITLE
Remove entries < 0.2% of total runtime

### DIFF
--- a/vprof/__main__.py
+++ b/vprof/__main__.py
@@ -36,6 +36,18 @@ _ERR_CODES = {
 }
 
 
+def cut_stats(program_stats, threshold=0.002):
+    """Remove entries from program stats that make less than `threshold` % of
+    the total run time."""
+    if 'h' in program_stats:
+        total_time = sum(h['runTime'] for h in program_stats['h']['heatmaps'])
+        program_stats['h']['heatmaps'] = [
+            h for h in program_stats['h']['heatmaps']
+            if h['runTime'] >= threshold * total_time
+        ]
+    return program_stats
+
+
 def main():
     """Main function of the module."""
     parser = argparse.ArgumentParser(
@@ -96,10 +108,10 @@ def main():
         if args.output_file:
             with open(args.output_file, 'w') as outfile:
                 program_stats['version'] = __version__
-                outfile.write(json.dumps(program_stats, indent=2))
+                outfile.write(json.dumps(cut_stats(program_stats), indent=2))
         else:
             stats_server.start(
-                args.host, args.port, program_stats,
+                args.host, args.port, cut_stats(program_stats),
                 args.dont_start_browser, args.debug_mode)
 
 if __name__ == "__main__":


### PR DESCRIPTION
If you have a lot of files (say, thousands), many of them aren't going to account for more than 0.X% of total runtime. However they will be rendered in the result list, making the UI load for a very long time or crash.

This is a working PoC of removing any entry <0.2% of total runtime from the results prior to serving them to the UI.

Another approach may be to include only the top 99% (or whatever) time consumers, but this didn't work as well as the fixed threshold approach.