### PR TITLE
Prevent crash on unexpected type repr

### DIFF
--- a/vprof/memory_profiler.py
+++ b/vprof/memory_profiler.py
@@ -71,8 +71,9 @@ def _format_obj_count(objects):
     for obj_type, obj_count in objects.items():
         if obj_count != 0:
             match = re.findall(regex, repr(obj_type))
-            obj_type, obj_name = match[0]
-            result.append(("%s %s" % (obj_type, obj_name), obj_count))
+            if match:
+                obj_type, obj_name = match[0]
+                result.append(("%s %s" % (obj_type, obj_name), obj_count))
     return sorted(result, key=operator.itemgetter(1), reverse=True)
 
 


### PR DESCRIPTION
For arbitrary types, `repr(type(obj))` is not guaranteed to be of any particular form. Thus, you can't assume that the regex will match something, and therefore the `match[0]` call needs to be put under a check to make sure that `match` actually contains something first.

As an example of a type repr that doesn't conform to what you are expecting in the standard library:
```
from typing import TypeVar
x = TypeVar("x")
print(type(x))  # prints "typing.TypeVar"
```