### PR TITLE
Added LICENSE to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ include vprof/ui/css/progress.gif
 include vprof/ui/favicon.ico
 include requirements.txt
 include dev_requirements.txt
+include LICENSE


### PR DESCRIPTION
I would like to package vprof on conda-forge; can you please add the license to the source code since this is generally recommended?

For the time being, I will package vprof without the license file, but when you will push a new version with this addition on pypy I will add it on conda-forge too.

Thank! :)