### PR TITLE
Adapt to breaking API changes in pip>=10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ import shlex
 import subprocess
 import unittest
 
+import pkg_resources
 from distutils import cmd
 from setuptools import setup
 from setuptools.command.install import install
-from pip.download import PipSession
-from pip.req import parse_requirements
 
 
 class RunUnittestsCommand(cmd.Command):
@@ -126,6 +125,11 @@ def get_description():
         return readme_file.read()
 
 
+def get_requirements():
+    with open('requirements.txt') as fp:
+        return [str(r) for r in pkg_resources.parse_requirements(fp)]
+
+
 setup(
     name='vprof',
     version=get_vprof_version('vprof/__main__.py'),
@@ -153,10 +157,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Topic :: Software Development',
     ],
-    install_requires=[
-        str(req.req) for req in parse_requirements('requirements.txt',
-                                                   session=PipSession())
-    ],
+    install_requires=get_requirements(),
     long_description=get_description(),
     cmdclass={
         'test': RunUnittestsCommand,


### PR DESCRIPTION
In the newest release, `pip` has hidden all of its API in an `_internal` package, emphasizing that no public API exist in `pip` (see [related issue](https://github.com/pypa/pip/pull/4700)). Due to that, many packages relying on once public `pip` API and importing `pip.*` can't be built anymore, including `vprof`. This PR proposes using requirements parsing from `pkg_resources` (part of `setuptools` package) instead of fixing the imports to `pip._internal.download.PipSession` and `pip._internal.parse_requirements`. The advantage of this is that `pkg_resources.parse_requirements` is part of a [public API](http://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing) that is unlikely to change in future.