### PR TITLE
Any return type for result

### DIFF
--- a/vprof/runner.py
+++ b/vprof/runner.py
@@ -92,7 +92,7 @@ def run(func, options, args=(), kwargs={}, host='localhost', port=8000):  # pyli
 
     result = None
     for prof in run_stats:
-        if not result:
+        if result is None:
             result = run_stats[prof]['result']
         del run_stats[prof]['result']  # Don't send result to remote host
 


### PR DESCRIPTION
It is safer to check for None, in case the function returns non-standard python variable (ex numpy of tensorflow)
Should fix https://github.com/nvdv/vprof/issues/102