### PR TITLE
docs: fix simple typo, enchanchements -> enhancements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported.
 * Include screenshots if it helps to demonstrate the problem.
 * Include version vprof, Python, name and version of OS you are using.
 
-### Suggesting enchanchements
+### Suggesting enhancements
 Before creating feature request, please check if the feature has already been
 requested or implemented.
 


### PR DESCRIPTION
There is a small typo in CONTRIBUTING.md.

Should read `enhancements` rather than `enchanchements`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md